### PR TITLE
训练支持

### DIFF
--- a/configs/_base_/datasets/ymir_coco.py
+++ b/configs/_base_/datasets/ymir_coco.py
@@ -1,0 +1,64 @@
+# dataset settings
+dataset_type = 'mmdet.CocoDataset'
+data_root = '/in'
+file_client_args = dict(backend='disk')
+
+# TODO for dark image, pad_val = 0; for other image, pad_val = 114
+train_pipeline = [
+    dict(type='mmdet.LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='mmdet.LoadAnnotations', with_bbox=True, with_mask=True, poly2mask=False),
+    dict(type='ConvertMask2BoxType', box_type='rbox'),
+    dict(type='mmdet.Resize', scale=(512, 512), keep_ratio=True),
+    dict(type='mmdet.Pad', size=(512, 512), pad_val=dict(img=(114, 114, 114))),
+    dict(type='mmdet.RandomFlip', prob=0.75, direction=['horizontal', 'vertical', 'diagonal']),
+    dict(type='mmdet.PackDetInputs')
+]
+val_pipeline = [
+    dict(type='mmdet.LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='mmdet.Resize', scale=(512, 512), keep_ratio=True),
+    dict(type='mmdet.Pad', size=(512, 512), pad_val=dict(img=(114, 114, 114))),
+    # avoid bboxes being resized
+    dict(type='mmdet.LoadAnnotations', with_bbox=True, with_mask=True, poly2mask=False),
+    dict(type='ConvertMask2BoxType', box_type='rbox'),
+    dict(type='mmdet.PackDetInputs',
+         meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape', 'scale_factor', 'instances'))
+]
+test_pipeline = [
+    dict(type='mmdet.LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='mmdet.Resize', scale=(512, 512), keep_ratio=True),
+    dict(type='mmdet.Pad', size=(512, 512), pad_val=dict(img=(114, 114, 114))),
+    dict(type='mmdet.PackDetInputs', meta_keys=('img_id', 'img_path', 'ori_shape', 'img_shape', 'scale_factor'))
+]
+
+metainfo = dict(classes=('ship', ))
+
+train_dataloader = dict(batch_size=2,
+                        num_workers=2,
+                        persistent_workers=True,
+                        sampler=dict(type='DefaultSampler', shuffle=True),
+                        batch_sampler=None,
+                        dataset=dict(type=dataset_type,
+                                     metainfo=metainfo,
+                                     data_root=data_root,
+                                     ann_file='/out/ymir_dataset/ymir_train.json',
+                                     data_prefix=dict(img='/in/assets'),
+                                     filter_cfg=dict(filter_empty_gt=True),
+                                     pipeline=train_pipeline))
+val_dataloader = dict(batch_size=1,
+                      num_workers=2,
+                      persistent_workers=True,
+                      drop_last=False,
+                      sampler=dict(type='DefaultSampler', shuffle=False),
+                      dataset=dict(type=dataset_type,
+                                   metainfo=metainfo,
+                                   data_root=data_root,
+                                   ann_file='/out/ymir_dataset/ymir_val.json',
+                                   data_prefix=dict(img='/in/assets'),
+                                   test_mode=True,
+                                   pipeline=val_pipeline))
+test_dataloader = val_dataloader
+
+val_evaluator = dict(type='DOTAMetric', metric='mAP')
+# val_evaluator = dict(type='RotatedCocoMetric', metric='bbox')
+
+test_evaluator = val_evaluator

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 -r requirements/optional.txt
 -r requirements/runtime.txt
 -r requirements/tests.txt
+-r requirements/ymir.txt

--- a/requirements/ymir.txt
+++ b/requirements/ymir.txt
@@ -1,0 +1,7 @@
+opencv-contrib-python>=4.0
+easydict
+tqdm
+imagesize
+nptyping
+tensorboard
+-e git+https://github.com/modelai/ymir-executor-sdk.git@ymir2.1.0#egg=ymir-exc

--- a/tools/train.py
+++ b/tools/train.py
@@ -3,14 +3,15 @@ import argparse
 import logging
 import os
 import os.path as osp
-
 from mmdet.utils import register_all_modules as register_all_modules_mmdet
 from mmengine.config import Config, DictAction
 from mmengine.logging import print_log
 from mmengine.registry import RUNNERS
 from mmengine.runner import Runner
+from ymir_exc.util import get_merged_config
 
 from mmrotate.utils import register_all_modules
+from ymir.utils.common import modify_mmengine_config
 
 
 def parse_args():
@@ -63,6 +64,9 @@ def main():
 
     # load config
     cfg = Config.fromfile(args.config)
+    ymir_cfg = get_merged_config()
+    modify_mmengine_config(cfg, ymir_cfg)
+
     cfg.launcher = args.launcher
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)

--- a/ymir/Dockerfile
+++ b/ymir/Dockerfile
@@ -1,0 +1,37 @@
+FROM pytorch/pytorch:1.11.0-cuda11.3-cudnn8-runtime
+
+# To fix GPG key error when running apt-get update
+RUN apt-get update && apt-get install -y gnupg2
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1804/x86_64/7fa2af80.pub
+
+# (Optional)
+RUN sed -i 's/http:\/\/archive.ubuntu.com\/ubuntu\//http:\/\/mirrors.aliyun.com\/ubuntu\//g' /etc/apt/sources.list && \
+   pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
+
+RUN apt-get update \
+    && apt-get install -y gcc ffmpeg libsm6 libxext6 git ninja-build libglib2.0-0 libxrender-dev vim \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip install openmim \
+    && mim install "mmengine>=0.3.1" \
+    && mim install "mmcv>=2.0.0rc1,<2.1.0" \
+    && mim install "mmdet>=3.0.0rc5,<3.1.0"
+
+# Install MMYOLO
+COPY . /app
+RUN cd /app && \
+    pip install --no-cache-dir -r requirements.txt && \
+    mkdir -p /img-man && \
+    mv ymir/img-man/*.yaml /img-man && \
+    mkdir /weights && \
+    mv ymir/weights/*.pth /weights && \
+    mkdir -p /root/.cache/torch/hub/checkpoints && \
+    mv ymir/weights/imagenet/*.pth /root/.cache/torch/hub/checkpoints
+
+ENV PYTHONPATH=.
+WORKDIR /app
+
+RUN echo "python3 ymir/start.py" > /usr/bin/start.sh
+CMD bash /usr/bin/start.sh

--- a/ymir/fast.dockerfile
+++ b/ymir/fast.dockerfile
@@ -1,0 +1,17 @@
+FROM youdaoyzbx/ymir-executor:ymir2.1.0-mmrotate-cu113-base
+
+COPY . /app
+RUN cd /app && \
+    pip install --no-cache-dir -r requirements.txt && \
+    mkdir -p /img-man && \
+    mv ymir/img-man/*.yaml /img-man
+# mkdir /weights && \
+# mv ymir/weights/*.pth /weights && \
+# mkdir -p /root/.cache/torch/hub/checkpoints && \
+# mv ymir/weights/imagenet/*.pth /root/.cache/torch/hub/checkpoints
+
+ENV PYTHONPATH=.
+WORKDIR /app
+
+RUN echo "python3 ymir/start.py" > /usr/bin/start.sh
+CMD bash /usr/bin/start.sh

--- a/ymir/img-man/infer-template.yaml
+++ b/ymir/img-man/infer-template.yaml
@@ -1,0 +1,2 @@
+conf_threshold: 0.2
+iou_threshold: 0.65

--- a/ymir/img-man/manifest.yaml
+++ b/ymir/img-man/manifest.yaml
@@ -1,0 +1,1 @@
+object_type: 2  # object detection

--- a/ymir/img-man/mining-template.yaml
+++ b/ymir/img-man/mining-template.yaml
@@ -1,0 +1,3 @@
+mining_algorithm: 'entropy'
+conf_threshold: 0.1
+iou_threshold: 0.65

--- a/ymir/img-man/training-template.yaml
+++ b/ymir/img-man/training-template.yaml
@@ -1,0 +1,11 @@
+export_format: 'ark:raw'
+samples_per_gpu: 8  # batch size per gpu
+workers_per_gpu: 4
+max_epochs: 100
+model_name: rtmdet_tiny
+args_options: ''
+cfg_options: ''
+img_size: 512
+val_interval: 1  # <0 means evaluation every interval
+max_keep_checkpoints: 1  # <0 means save all weight file, 1 means save last and best weight files, k means save topk best weight files and topk epoch/step weigth files
+# ymir_saved_file_patterns: ''  # custom saved files, support python regular expression, use , to split multiple pattern

--- a/ymir/tests/test_mmrotate.py
+++ b/ymir/tests/test_mmrotate.py
@@ -1,0 +1,10 @@
+from mmdet.apis import inference_detector, init_detector
+
+from mmrotate.utils import register_all_modules
+
+if __name__ == '__main__':
+    register_all_modules(init_default_scope=True)
+    config_file = 'configs/rotated_rtmdet/rotated_rtmdet_tiny-3x-dota.py'
+    checkpoint_file = 'ymir/weights/rotated_rtmdet_tiny-3x-dota-9d821076.pth'
+    model = init_detector(config_file, checkpoint_file, device='cuda:0')
+    inference_detector(model, 'demo/demo.jpg')

--- a/ymir/tools/ssdd_to_ymir.py
+++ b/ymir/tools/ssdd_to_ymir.py
@@ -1,0 +1,152 @@
+"""
+convert SAR ship detection dataset (SSDD) dataset to ymir detection import format
+
+view https://github.com/open-mmlab/mmrotate/blob/main/tools/data/ssdd/README.md for detail
+
+SSDD
+├── test
+│   ├── all
+│   │   ├── images
+│   │   ├── labelTxt
+│   │   └── test.json
+│   ├── inshore
+│   │   ├── images
+│   │   └── labelTxt
+│   └── offshore
+│       ├── images
+│       └── labelTxt
+└── train
+    ├── images
+    ├── labelTxt
+    └── train.json
+
+YMIR-SSDD
+└── train
+    ├── gt
+    └── images
+└── val
+    ├── gt
+    └── images
+"""
+
+import argparse
+import cv2
+import json
+import numpy as np
+import os
+import os.path as osp
+import random
+import shutil
+from typing import List
+
+
+def qbox2rbox(qbox: List[float]) -> List[float]:
+    """_summary_
+
+    Parameters
+    ----------
+    qbox : _type_
+        _description_
+
+    view `from mmrotate.structures import qbox2rbox`
+    """
+    assert len(qbox) == 8, f'qbox = {qbox}'
+    pts = np.array(qbox, dtype=np.float32).reshape(4, 2)
+    (x, y), (w, h), angle = cv2.minAreaRect(pts)
+    return [x, y, w, h, angle / 180 * np.pi]
+
+
+def get_args():
+    parser = argparse.ArgumentParser("convert SAR ship detection dataset (SSDD) to ymir")
+    parser.add_argument("--root_dir", help="root dir for SSDD dataset")
+    parser.add_argument("--split", choices=['train', 'test'], default="train", help="split for dataset")
+    parser.add_argument("--out_dir", help="the output directory", default="./out")
+    parser.add_argument("--num", help="sample number for dataset", default=0, type=int)
+
+    return parser.parse_args()
+
+
+def coco_to_xml(img, anns, xml_path):
+    with open(xml_path, 'w') as fp:
+        fp.write(f"""<annotation>
+	<folder>images</folder>
+	<filename>{img['file_name']}</filename>
+	<source>
+		<database>SAR ship detection dataset (SSDD)</database>
+		<annotation>PASCAL VOC2007</annotation>
+	</source>
+	<size>
+		<width>{img['width']}</width>
+		<height>{img['height']}</height>
+		<depth>3</depth>
+	</size>
+	<segmented>0</segmented>""")
+
+        for ann in anns:
+            qbox = ann['segmentation'][0]
+            assert len(ann['segmentation']) == 1, f'ann = {ann}'
+            xc, yc, w, h, angle = qbox2rbox(qbox)
+            xmin = round(xc - w / 2)
+            xmax = round(xc + w / 2)
+            ymin = round(yc - h / 2)
+            ymax = round(yc + h / 2)
+
+            fp.write(f"""
+	<object>
+		<name>SAR ship</name>
+		<pose>Rear</pose>
+		<truncated>0</truncated>
+		<difficult>0</difficult>
+		<bndbox>
+			<xmin>{xmin}</xmin>
+			<ymin>{ymin}</ymin>
+			<xmax>{xmax}</xmax>
+			<ymax>{ymax}</ymax>
+            <rotate_angle>{angle}</rotate_angle>
+		</bndbox>
+	</object>""")
+
+        fp.write("\n</annotation>")
+
+
+if __name__ == '__main__':
+    args = get_args()
+
+    if args.split == 'train':
+        json_file = osp.join(args.root_dir, args.split, 'train.json')
+    else:
+        json_file = osp.join(args.root_dir, args.split, 'all', 'test.json')
+
+    with open(json_file, 'r') as fp:
+        data = json.load(fp)
+
+    if args.num > 0:
+        num = min(len(data['images']), args.num)
+        images = random.choices(data['images'], k=num)
+    else:
+        images = data['images']
+
+    out_dir = osp.join(args.out_dir, args.split)
+    os.makedirs(out_dir, exist_ok=True)
+    os.makedirs(osp.join(out_dir, 'images'), exist_ok=True)
+    os.makedirs(osp.join(out_dir, 'gt'), exist_ok=True)
+
+    for img in images:
+        if args.split == 'train':
+            img_path = osp.join(args.root_dir, args.split, 'images', img['file_name'])
+        else:
+            img_path = osp.join(args.root_dir, args.split, 'all', 'images', img['file_name'])
+
+        if not osp.exists(img_path):
+            img_path = osp.splitext(img_path)[0] + '.png'
+        assert osp.exists(img_path), f'{img_path} not exist'
+
+        des_path = osp.join(out_dir, 'images', img['file_name'])
+        assert not osp.exists(des_path)
+        shutil.copy(img_path, des_path)
+
+        anns = [ann for ann in data['annotations'] if ann['image_id'] == img['id']]
+
+        xml_path = osp.join(out_dir, 'gt', osp.splitext(img['file_name'])[0] + '.xml')
+        assert not osp.exists(xml_path)
+        coco_to_xml(img, anns, xml_path)

--- a/ymir/utils/common.py
+++ b/ymir/utils/common.py
@@ -1,0 +1,352 @@
+"""
+utils function for ymir and yolov5
+"""
+import difflib
+import glob
+import logging
+import os
+import os.path as osp
+import warnings
+from easydict import EasyDict as edict
+from mmengine.config import Config, ConfigDict
+from typing import Any, Dict, Iterable, List, Union
+from ymir_exc.dataset_convert import convert_ymir_to_coco
+from ymir_exc.util import get_bool
+
+from ymir.utils.ymir_training_monitor_hook import YmirTrainingMonitorHook
+
+
+def recursive_modify_attribute(mmengine_cfgdict: Union[Config, ConfigDict], attribute_key: str, attribute_value: Any):
+    """
+    recursive modify mmcv_cfg:
+        1. mmcv_cfg.attribute_key to attribute_value
+        2. mmcv_cfg.xxx.xxx.xxx.attribute_key to attribute_value (recursive)
+        3. mmcv_cfg.xxx[i].attribute_key to attribute_value (i=0, 1, 2 ...)
+        4. mmcv_cfg.xxx[i].xxx.xxx[j].attribute_key to attribute_value
+    """
+    for key in mmengine_cfgdict:
+        if key == attribute_key:
+            mmengine_cfgdict[key] = attribute_value
+            logging.info(f'modify {mmengine_cfgdict}, {key} = {attribute_value}')
+        elif isinstance(mmengine_cfgdict[key], (Config, ConfigDict)):
+            recursive_modify_attribute(mmengine_cfgdict[key], attribute_key, attribute_value)
+        elif isinstance(mmengine_cfgdict[key], Iterable):
+            for cfg in mmengine_cfgdict[key]:
+                if isinstance(cfg, (Config, ConfigDict)):
+                    recursive_modify_attribute(cfg, attribute_key, attribute_value)
+
+
+def get_mmengine_dataset_config(ymir_cfg: edict) -> Config:
+    """get mmengine dataset config
+
+    Parameters
+    ----------
+    ymir_cfg : edict
+        ymir merged config
+
+    Returns
+    -------
+    Config
+        dataset config
+    """
+    # modify dataset config
+    data_info = convert_ymir_to_coco(cat_id_from_zero=True)
+    file_cfg = Config.fromfile('configs/_base_/datasets/ymir_coco.py')
+
+    file_cfg.data_root = ymir_cfg.ymir.input.root_dir
+    img_size = int(ymir_cfg.param.get('img_size', 512))
+    samples_per_gpu = int(ymir_cfg.param.samples_per_gpu)
+    workers_per_gpu = int(ymir_cfg.param.workers_per_gpu)
+    file_cfg.train_dataloader.batch_size = samples_per_gpu
+    file_cfg.train_dataloader.num_workers = workers_per_gpu
+
+    metainfo = dict(classes=ymir_cfg.param.class_names)
+    file_cfg.metainfo = metainfo
+    for split in ['train', 'val', 'test']:
+        for transform in file_cfg[f'{split}_pipeline']:
+            if 'scale' in transform:
+                assert transform.type == 'mmdet.Resize'
+                transform.scale = (img_size, img_size)
+            elif 'size' in transform:
+                assert transform.type == 'mmdet.Pad'
+                transform.size = (img_size, img_size)
+
+        if split == 'test':
+            continue
+
+        ymir_dataset_cfg = dict(type='mmdet.CocoDataset',
+                                ann_file=data_info[split]['ann_file'],
+                                metainfo=metainfo,
+                                data_root=ymir_cfg.ymir.input.root_dir,
+                                data_prefix=dict(img='/in/assets'),
+                                test_mode=split == 'val',
+                                filter_cfg=dict(filter_empty_gt=False),
+                                pipeline=file_cfg[f'{split}_pipeline'])
+
+        file_cfg[f'{split}_dataloader'].dataset.update(ymir_dataset_cfg)
+
+    file_cfg.test_dataloader = file_cfg.val_dataloader
+
+    return file_cfg
+
+
+def modify_mmengine_config(mmengine_cfg: Config, ymir_cfg: edict) -> None:
+    """
+    useful for training process
+    - modify dataset config
+    - modify model output channel
+    - modify epochs, checkpoint, tensorboard config
+    """
+
+    # validation may augment the image and use more gpu
+    # so set smaller samples_per_gpu for validation
+    samples_per_gpu = int(ymir_cfg.param.samples_per_gpu)
+    workers_per_gpu = int(ymir_cfg.param.workers_per_gpu)
+    mmengine_cfg.train_batch_size_per_gpu = samples_per_gpu
+    mmengine_cfg.train_num_workers = workers_per_gpu
+
+    if 'batch_size_per_gpu' in mmengine_cfg.optim_wrapper.optimizer:
+        mmengine_cfg.optim_wrapper.optimizer.batch_size_per_gpu = samples_per_gpu
+
+    # modify model output channel
+    num_classes = len(ymir_cfg.param.class_names)
+    mmengine_cfg.num_classes = num_classes
+    recursive_modify_attribute(mmengine_cfg.model, 'num_classes', num_classes)
+
+    ymir_dataset_cfg = get_mmengine_dataset_config(ymir_cfg)
+    # overwrite dataset config
+    for split in ['train', 'val', 'test']:
+        mmengine_cfg[f'{split}_pipeline'] = ymir_dataset_cfg[f'{split}_pipeline']
+        mmengine_cfg[f'{split}_dataloader'] = ymir_dataset_cfg[f'{split}_dataloader']
+
+        if split != 'train':
+            mmengine_cfg[f'{split}_evaluator'] = ymir_dataset_cfg[f'{split}_evaluator']
+    # update dataset_type, data_root and other
+    mmengine_cfg.update(ymir_dataset_cfg)
+
+    # modify max_epochs
+    if ymir_cfg.param.get('max_epochs', None):
+        max_epochs = int(ymir_cfg.param.max_epochs)
+        mmengine_cfg.train_cfg.max_epochs = max_epochs
+        mmengine_cfg.max_epochs = max_epochs
+
+    # modify checkpoint
+    mmengine_cfg.default_hooks.checkpoint['out_dir'] = ymir_cfg.ymir.output.models_dir
+    mmengine_cfg.default_hooks.checkpoint['save_best'] = 'auto'
+
+    # modify tensorboard
+    tensorboard_logger = dict(type='TensorboardVisBackend', save_dir=ymir_cfg.ymir.output.tensorboard_dir)
+    if len(mmengine_cfg.visualizer.vis_backends) <= 1:
+        mmengine_cfg.visualizer.vis_backends.append(tensorboard_logger)
+    else:
+        mmengine_cfg.visualizer.vis_backends[1].update(tensorboard_logger)
+
+    # TODO save only the best top-k model weight files.
+    # modify evaluation and interval
+    val_interval: int = int(ymir_cfg.param.get('val_interval', 1))
+    if val_interval > 0:
+        val_interval = min(val_interval, mmengine_cfg.train_cfg.max_epochs)
+    else:
+        val_interval = 1
+
+    mmengine_cfg.save_epoch_intervals = val_interval
+    mmengine_cfg.train_cfg.val_interval = val_interval
+
+    # save best top-k model weights files
+    # max_keep_ckpts <= 0  # save all checkpoints
+    max_keep_ckpts: int = int(ymir_cfg.param.get('max_keep_checkpoints', 1))
+    mmengine_cfg.default_hooks.checkpoint.interval = val_interval
+    mmengine_cfg.default_hooks.checkpoint.max_keep_ckpts = max_keep_ckpts
+
+    # fix DDP error or make training faster?
+    mmengine_cfg.find_unused_parameters = get_bool(ymir_cfg, 'find_unused_parameters', False)
+
+    # learning rate
+    if ymir_cfg.param.get('learning_rate', None):
+        mmengine_cfg.base_lr = float(ymir_cfg.param.learning_rate)
+        mmengine_cfg.optim_wrapper.optimizer.lr = float(ymir_cfg.param.learning_rate)
+
+    # set training log interval (iter)
+    with open(ymir_cfg.ymir.input.training_index_file, 'r') as fp:
+        train_dataset_size = len(fp.readlines())
+    gpu_id: str = str(ymir_cfg.param.get("gpu_id", ''))
+    num_gpus = len(gpu_id.split(","))
+    max_interval = train_dataset_size // (samples_per_gpu * num_gpus)
+
+    log_interval = max(1, min(50, max_interval))
+    mmengine_cfg.default_hooks.logger.interval = log_interval
+
+    # add YmirTrainingMonitorHook
+    # HOOKS.register_module(module=YmirTrainingMonitorHook)
+    ymir_hook = dict(type='YmirTrainingMonitorHook', interval=log_interval)
+    mmengine_cfg.custom_hooks.append(ymir_hook)
+
+    # set work dir
+    mmengine_cfg.work_dir = ymir_cfg.ymir.output.models_dir
+
+    args_options = ymir_cfg.param.get("args_options", '')
+    cfg_options = ymir_cfg.param.get("cfg_options", '')
+
+    # auto load offered weight file if not set by user!
+    if (args_options.find('--resume-from') == -1 and args_options.find('--load-from') == -1
+            and cfg_options.find('load_from') == -1 and cfg_options.find('resume_from') == -1):  # noqa: E129
+
+        weight_file = get_best_weight_file(ymir_cfg)
+        if weight_file:
+            if cfg_options:
+                cfg_options += f' load_from={weight_file}'
+            else:
+                cfg_options = f'load_from={weight_file}'
+        else:
+            logging.warning('no weight file used for training!')
+
+
+def get_best_weight_file(cfg: edict) -> str:
+    """
+    return the weight file path by priority
+    find weight file in cfg.param.pretrained_model_params or cfg.param.model_params_path
+    load coco-pretrained weight for yolox
+    """
+    if cfg.ymir.run_training:
+        model_params_path: List[str] = cfg.param.get('pretrained_model_params', [])
+    else:
+        model_params_path = cfg.param.get('model_params_path', [])
+
+    model_dir = cfg.ymir.input.models_dir
+    model_params_path = [
+        osp.join(model_dir, p) for p in model_params_path
+        if osp.exists(osp.join(model_dir, p)) and p.endswith(('.pth', '.pt'))
+    ]
+
+    # choose weight file by priority, best_xxx.pth > latest.pth > epoch_xxx.pth
+    epoch_pth_files = [f for f in model_params_path if osp.basename(f).startswith(('epoch_', 'iter_'))]
+    best_pth_files = [f for f in model_params_path if f not in epoch_pth_files]
+
+    if len(best_pth_files) > 0:
+        return max(best_pth_files, key=os.path.getctime)
+    if len(epoch_pth_files) > 0:
+        return max(epoch_pth_files, key=os.path.getctime)
+
+    if cfg.ymir.run_training:
+        weight_files = [f for f in glob.glob('/weights/**/*', recursive=True) if f.endswith(('.pth', '.pt'))]
+
+        # load pretrained model weight for target model
+        config_file = get_config_file(cfg)
+        if len(weight_files) > 0:
+            # use basename to avoid directory name change match result
+            matched_weight_files = difflib.get_close_matches(osp.basename(config_file), weight_files)
+            if len(matched_weight_files) > 0:
+                logging.info(f'load yolox pretrained weight {matched_weight_files[0]}')
+                return matched_weight_files[0]
+    return ""
+
+
+def get_topk_checkpoints(files: List[str], k: int) -> List[str]:
+    """
+    keep topk checkpoint files, remove other files.
+
+    1. keep topk best checkpoint for ensembel
+    2. keep topk latest checkpoint for quantization
+    """
+    checkpoints_files = [f for f in files if f.endswith(('.pth', '.pt'))]
+
+    epoch_pth_files = [f for f in checkpoints_files if osp.basename(f).startswith(('epoch_', 'iter_'))]
+    if len(epoch_pth_files) > 0:
+        topk_epoch_pth_files = sorted(epoch_pth_files, key=os.path.getctime, reverse=True)
+    else:
+        topk_epoch_pth_files = []
+
+    # best weight files may not name with best, use the other instead
+    best_pth_files = [f for f in checkpoints_files if f not in epoch_pth_files]
+    if len(best_pth_files) > 0:
+        # newest first
+        topk_best_pth_files = sorted(best_pth_files, key=os.path.getctime, reverse=True)
+    else:
+        topk_best_pth_files = []
+
+    # python will check the length of list
+    if k < 0:
+        return checkpoints_files
+    else:
+        return topk_best_pth_files[0:k] + topk_epoch_pth_files[0:k]
+
+
+def get_id_for_config_files() -> dict:
+    """
+    use id instead of config_file:
+    rtmdet_tiny: configs/rotated_rtmdet/rotated_rtmdet_l-3x-dota_ms.py
+
+    note: '-' will be replace with '_'
+    """
+
+    py_files = glob.glob(osp.join('configs', '*', '*dota.py'))
+
+    config_files = [f for f in py_files if f.split('/')[1] not in ['_base_', 'deploy']]
+
+    id_dict: Dict[str, str] = {}
+    for f in config_files:
+        f_name = osp.basename(f).replace('-', '_')
+        splits = f_name.split('_')
+
+        # remove rotated keywords
+        if splits[0] == 'rotated':
+            splits = splits[1:]
+
+        # retinanet, fcos, rtmdet, ...
+        for x in range(2, len(splits)):
+            idx = '_'.join(splits[0:x])
+            id_dict[idx] = f
+
+        id_dict[f] = f
+
+    return id_dict
+
+
+def get_config_file(cfg: edict) -> str:
+    """get config file path from ymir config
+
+    for training task, get config file from hyper-parameter model_name
+    for mining and infer task, get config file from weight files
+
+    Parameters
+    ----------
+    cfg : easydict.EasyDict
+        ymir merged config
+
+    Returns
+    -------
+    str
+        config file path for mmengine model
+
+    Raises
+    ------
+    Exception
+        KeyError('config_id not in dicts')
+        Exception('no config_file found')
+    """
+    if cfg.ymir.run_training:
+        # for training task, get config file from hyper-parameter model_name
+        model_name = cfg.param.get("model_name")
+        config_files_map = get_id_for_config_files()
+        config_id = model_name.lower().replace('-', '_')
+        if config_id not in config_files_map:
+            raise KeyError(f'{config_id} not in {config_files_map}')
+
+        config_file = config_files_map[config_id]
+        return config_file
+    else:
+        # for mining and infer task, get config file from weight files
+        model_params_path: List = cfg.param.get('model_params_path', [])  # type: ignore
+
+        model_dir = cfg.ymir.input.models_dir
+        config_files = [
+            osp.join(model_dir, p) for p in model_params_path
+            if osp.exists(osp.join(model_dir, p)) and p.endswith(('.py'))
+        ]
+
+        if len(config_files) > 0:
+            if len(config_files) > 1:
+                warnings.warn(f'multiple config file found! use {config_files[0]}')
+            return config_files[0]
+        else:
+            raise Exception(f'no config_file found in {model_dir} and {model_params_path}')

--- a/ymir/utils/dataset_convert.py
+++ b/ymir/utils/dataset_convert.py
@@ -1,0 +1,108 @@
+import imagesize
+import json
+import numpy as np
+import os
+import os.path as osp
+import torch
+from typing import Dict, List
+from ymir_exc.util import get_merged_config
+
+from mmrotate.structures import rbox2qbox
+
+
+def convert_ymir_to_coco(cat_id_from_zero: bool = False) -> Dict[str, Dict[str, str]]:
+    """
+    convert ymir detection dataset to coco format for training task
+    for the input index file:
+        ymir_index_file: for each line it likes: {img_path} \t {ann_path}
+
+    for the outout json file:
+        cat_id_from_zero: category id start from zero or not
+        for openmmlab: cat_id_from_zero = True
+        for detectron2: cat_id_from_zero = False
+
+    output the coco dataset information:
+        dict(train=dict(img_dir=xxx, ann_file=xxx),
+            val=dict(img_dir=xxx, ann_file=xxx))
+    """
+    cfg = get_merged_config()
+    export_format = cfg.param.export_format
+    assert export_format in ['ark:raw',
+                             'det-ark:raw'], f'unsupported export_format = {export_format}, not ark:raw or det-ark:raw'
+
+    out_dir = cfg.ymir.output.root_dir
+    ymir_dataset_dir = osp.join(out_dir, "ymir_dataset")
+
+    output_info = {}
+    # avoid convert multiple times
+    if osp.exists(ymir_dataset_dir):
+        for split in ['train', 'val']:
+            split_json_file = osp.join(ymir_dataset_dir, f"ymir_{split}.json")
+            output_info[split] = dict(img_dir=cfg.ymir.input.assets_dir, ann_file=split_json_file)
+        return output_info
+
+    # avoid convert in other rank
+    RANK = int(os.getenv('RANK', -1))
+    assert RANK in [0, -1], f'convert dataset in rank = {RANK}, not 0 or -1'
+    os.makedirs(ymir_dataset_dir, exist_ok=True)
+
+    for split, prefix in zip(["train", "val"], ["training", "val"]):
+        ymir_index_file = getattr(cfg.ymir.input, f"{prefix}_index_file")
+        with open(ymir_index_file) as fp:
+            lines = fp.readlines()
+
+        img_id = 0
+        ann_id = 0
+        data: Dict[str, List] = dict(images=[], annotations=[], categories=[], licenses=[])
+
+        cat_id_start = 0 if cat_id_from_zero else 1
+        for id, name in enumerate(cfg.param.class_names):
+            data["categories"].append(dict(id=id + cat_id_start, name=name, supercategory="none"))
+
+        for line in lines:
+            img_file, ann_file = line.strip().split()
+            width, height = imagesize.get(img_file)
+            img_info = dict(file_name=img_file, height=height, width=width, id=img_id)
+
+            data["images"].append(img_info)
+
+            if osp.exists(ann_file):
+                for ann_line in open(ann_file, "r").readlines():
+                    ann_strlist = ann_line.strip().split(",")
+                    class_id, x1, y1, x2, y2 = [int(s) for s in ann_strlist[0:5]]
+                    angle = float(ann_strlist[6])
+
+                    bbox_xc = (x1 + x2) / 2
+                    bbox_yc = (y1 + y2) / 2
+                    bbox_width = x2 - x1
+                    bbox_height = y2 - y1
+                    rbox = torch.from_numpy(np.array([[bbox_xc, bbox_yc, bbox_width, bbox_height, angle]]))
+                    qbox = rbox2qbox(rbox)
+                    # hbox = rbox2hbox(rbox)
+
+                    bbox_area = bbox_width * bbox_height
+                    bbox_quality = (float(ann_strlist[5]) if len(ann_strlist) > 5 and ann_strlist[5].isnumeric() else 1)
+                    ann_info = dict(
+                        bbox=[x1, y1, bbox_width, bbox_height],  # x,y,width,height
+                        area=bbox_area,
+                        score=1.0,
+                        bbox_quality=bbox_quality,
+                        rotate_angle=angle,
+                        iscrowd=0,
+                        segmentation=qbox.cpu().numpy().tolist(),
+                        category_id=class_id + cat_id_start,  # start from cat_id_start
+                        id=ann_id,
+                        image_id=img_id,
+                    )
+                    data["annotations"].append(ann_info)
+                    ann_id += 1
+
+            img_id += 1
+
+        split_json_file = osp.join(ymir_dataset_dir, f"ymir_{split}.json")
+        with open(split_json_file, "w") as fw:
+            json.dump(data, fw)
+
+        output_info[split] = dict(img_dir=cfg.ymir.input.assets_dir, ann_file=split_json_file)
+
+    return output_info

--- a/ymir/utils/ymir_training_monitor_hook.py
+++ b/ymir/utils/ymir_training_monitor_hook.py
@@ -1,0 +1,92 @@
+"""
+hook for ymir training process, write the monitor.txt, save the latest model
+"""
+import glob
+import logging
+import os.path as osp
+import re
+import warnings
+from mmengine.hooks import Hook
+from mmengine.registry import HOOKS
+from typing import Dict, Optional, Union
+from ymir_exc.util import (get_merged_config, write_ymir_monitor_process,
+                           write_ymir_training_result)
+
+
+@HOOKS.register_module()
+class YmirTrainingMonitorHook(Hook):
+    """
+    for epoch based training loop only.
+
+    1. write monitor.txt
+    2. save the latest checkpoint with id=last if exist, note the checkpoint maybe clear late.
+    3. save the latest best checkpoint with id=best if exist, note the checkpoint maybe clear late.
+    """
+    # the priority should lower than CheckpointHook (priority = VERY_LOW)
+    priority = 'LOWEST'
+
+    def __init__(self, interval: int = 10):
+        self.interval = interval
+        self.ymir_cfg = get_merged_config()
+
+    def after_train_iter(self,
+                         runner,
+                         batch_idx: int,
+                         data_batch: Optional[Union[dict, tuple, list]] = None,
+                         outputs: Optional[dict] = None) -> None:
+        if runner.rank in [0, -1] and self.every_n_inner_iters(batch_idx, self.interval):
+            percent = (runner.epoch + batch_idx / len(runner.train_dataloader)) / runner.max_epochs
+            write_ymir_monitor_process(self.ymir_cfg, task='training', naive_stage_percent=percent, stage='task')
+
+    def after_val_epoch(self, runner, metrics: Optional[Dict[str, float]] = None) -> None:
+        """
+        metrics: {'dota/mAP': 0.001, 'dota/AP50': 0.003}
+
+        evaluation_result: {'mAP': 0.001, 'AP50': 0.003}
+        """
+        if runner.rank in [0, -1]:
+            keys = [k for k in metrics.keys()]  # type: ignore
+            if keys[0].find('dota/') > -1:
+                N = len('dota/')
+            else:
+                raise Exception(f'unknown key in {metrics}')
+
+            evaluation_result = {key[N:]: value for key, value in metrics.items()}  # type: ignore
+
+            if not evaluation_result:
+                evaluation_result = {'mAP': 0}
+            out_dir = self.ymir_cfg.ymir.output.models_dir
+            cfg_files = glob.glob(osp.join(out_dir, '*.py'))
+
+            try:
+                test_cfg = runner.model.test_cfg
+                evaluate_config = dict(iou_thr=test_cfg.nms.iou_threshold, conf_thr=test_cfg.score_thr)
+            except (KeyError, AttributeError):
+                evaluate_config = None
+
+            best_ckpts = glob.glob(osp.join(out_dir, 'best_dota', '*.pth'))
+            if len(best_ckpts) > 0:
+                newest_best_ckpt = max(best_ckpts, key=osp.getctime)
+                best_epoch = int(re.findall(r'\d+', newest_best_ckpt)[0])
+                # if current checkpoint is the newest checkpoint, keep it
+                if best_epoch == runner.epoch:
+                    logging.info(f'epoch={runner.epoch}, save {newest_best_ckpt} to result.yaml')
+                    write_ymir_training_result(self.ymir_cfg,
+                                               files=[newest_best_ckpt] + cfg_files,
+                                               id='best',
+                                               evaluation_result=evaluation_result,
+                                               evaluate_config=evaluate_config)
+            else:
+                warnings.warn(f'no best checkpoint found on {runner.epoch}')
+
+            latest_ckpts = glob.glob(osp.join(out_dir, '*.pth'))
+            if len(latest_ckpts) > 0:
+                last_ckpt = max(latest_ckpts, key=osp.getctime)
+                logging.info(f'epoch={runner.epoch}, save {last_ckpt} to result.yaml')
+                write_ymir_training_result(self.ymir_cfg,
+                                           files=[last_ckpt] + cfg_files,
+                                           id='last',
+                                           evaluation_result=evaluation_result,
+                                           evaluate_config=evaluate_config)
+            else:
+                warnings.warn(f'no latest checkpoint found on {runner.epoch}')

--- a/ymir/weights/download_weight.sh
+++ b/ymir/weights/download_weight.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# rtmdet tiny/s/m
+wget https://download.openmmlab.com/mmrotate/v1.0/rotated_rtmdet/rotated_rtmdet_tiny-3x-dota/rotated_rtmdet_tiny-3x-dota-9d821076.pth
+wget https://download.openmmlab.com/mmrotate/v1.0/rotated_rtmdet/rotated_rtmdet_s-3x-dota/rotated_rtmdet_s-3x-dota-11f6ccf5.pth
+wget https://download.openmmlab.com/mmrotate/v1.0/rotated_rtmdet/rotated_rtmdet_m-3x-dota/rotated_rtmdet_m-3x-dota-beeadda6.pth
+
+# imagenet
+mkdir -p imagenet
+cd imagenet
+wget https://download.openmmlab.com/mmdetection/v3.0/rtmdet/cspnext_rsb_pretrain/cspnext-s_imagenet_600e.pth
+wget https://download.openmmlab.com/mmdetection/v3.0/rtmdet/cspnext_rsb_pretrain/cspnext-tiny_imagenet_600e.pth

--- a/ymir/ymir_training.py
+++ b/ymir/ymir_training.py
@@ -1,0 +1,153 @@
+import glob
+import logging
+import os
+import os.path as osp
+import re
+import subprocess
+import sys
+from easydict import EasyDict as edict
+from mmengine.config import Config
+from ymir_exc.util import (YmirStage, find_free_port, get_merged_config,
+                           write_ymir_monitor_process,
+                           write_ymir_training_result)
+
+from ymir.utils.common import (get_best_weight_file, get_config_file,
+                               get_topk_checkpoints)
+from ymir.utils.dataset_convert import convert_ymir_to_coco
+
+
+def _parse_log_line(line):
+    """
+    # normal evaluation line
+    02/07 11:05:25 - mmengine - INFO - Epoch(val) [1][232/232]  dota/mAP: 0.0000  dota/AP50: 0.0000
+    """
+    epoch = int(re.findall(r'\[\d+\]', line)[0][1:-1])
+    maps = [float(x) for x in re.findall(r'\d+\.\d+', line)]
+
+    N = len('dota/')
+    pattern = r'dota/\w*:'
+
+    keys = [x[N:-1] for x in re.findall(pattern, line)]
+    info = {key: map for key, map in zip(keys, maps)}
+    return epoch, info
+
+
+def write_mmyolo_training_result(cfg: edict) -> None:
+    """
+    save the best checkpoint for ymir after training.
+    keep the same id with YmirTrainingMonitorHook, make sure the saved checkpoint exist.
+    """
+    out_dir = cfg.ymir.output.models_dir
+    log_files = glob.glob(osp.join(out_dir, '*', '*.log'))
+
+    assert len(log_files) > 0
+    log_file = max(log_files, key=osp.getctime)
+
+    # only one log file
+    with open(log_file, 'r') as fp:
+        lines = fp.readlines()
+
+    log_info_dict = {}
+    for line in lines:
+        if line.find('dota/mAP:') > -1:
+            epoch, info = _parse_log_line(line)
+            log_info_dict[epoch] = info
+
+    # for the best files
+    cfg_files = glob.glob(osp.join(out_dir, '*.py'))
+    best_ckpts = glob.glob(osp.join(out_dir, 'best_dota', '*.pth'))
+
+    topk = cfg.param.max_keep_checkpoints
+    # skip the newest ckpt, note YmirTrainingMonitorHook will save newest ckpt.
+    topk_best_ckpts = get_topk_checkpoints(best_ckpts, topk)[1:]
+
+    mmengine_cfg = Config.fromfile(cfg_files[0])
+    evaluate_config = dict(iou_thr=mmengine_cfg.model.test_cfg.nms.iou_threshold,
+                           conf_thr=mmengine_cfg.model.test_cfg.score_thr)
+
+    for ckpt in topk_best_ckpts:
+        epoch = int(re.findall(r'\d+', ckpt)[0])
+        if epoch not in log_info_dict:
+            continue
+        write_ymir_training_result(cfg,
+                                   files=[ckpt] + cfg_files,
+                                   id=f'best_{epoch}',
+                                   evaluation_result=log_info_dict[epoch],
+                                   evaluate_config=evaluate_config)
+
+    # save the last ckpt only, note YmirTrainingMonitorHook will save the last ckpt too.
+    last_ckpt = max(glob.glob(osp.join(out_dir, 'epoch_*.pth')), key=osp.getctime)
+    last_epoch = int(re.findall(r'\d+', last_ckpt)[0])
+    if last_epoch in log_info_dict:
+        write_ymir_training_result(cfg,
+                                   files=[last_ckpt] + cfg_files,
+                                   id='last',
+                                   evaluation_result=log_info_dict[last_epoch],
+                                   evaluate_config=evaluate_config)
+
+
+def main(cfg: edict) -> int:
+    # default ymir config
+    gpu_id: str = str(cfg.param.get("gpu_id", ''))
+    num_gpus = len(gpu_id.split(","))
+
+    classes = cfg.param.class_names
+    num_classes = len(classes)
+    logging.info(f'num_classes = {num_classes}')
+
+    # convert dataset before ddp
+    data_info = convert_ymir_to_coco(cat_id_from_zero=True)
+    logging.info(f'convert dataset to {data_info}')
+
+    # mmcv args config
+    config_file = get_config_file(cfg)
+    # config_file = cfg.param.get("config_file")
+    args_options = cfg.param.get("args_options", '')
+    cfg_options = cfg.param.get("cfg_options", '')
+
+    # auto load offered weight file if not set by user!
+    if (args_options.find('--resume-from') == -1) and ((cfg_options.find('load_from') == -1
+                                                        and cfg_options.find('resume_from') == -1)):
+
+        weight_file = get_best_weight_file(cfg)
+        if weight_file:
+            if cfg_options:
+                cfg_options += f' load_from={weight_file}'
+            else:
+                cfg_options = f'load_from={weight_file}'
+        else:
+            logging.warning('no weight file used for training!')
+
+    write_ymir_monitor_process(cfg, task='training', naive_stage_percent=0.2, stage=YmirStage.POSTPROCESS)
+
+    work_dir = cfg.ymir.output.models_dir
+    if num_gpus == 0:
+        # view https://mmdetection.readthedocs.io/en/stable/1_exist_data_model.html#training-on-cpu
+        os.environ.setdefault('CUDA_VISIBLE_DEVICES', "-1")
+        cmd = f"python3 tools/train.py {config_file} " + \
+            f"--work-dir {work_dir}"
+    else:
+        os.environ.setdefault('CUDA_VISIBLE_DEVICES', gpu_id)
+        port = find_free_port()
+        os.environ.setdefault('PORT', str(port))
+        cmd = f"bash ./tools/dist_train.sh {config_file} {num_gpus} " + \
+            f"--work-dir {work_dir}"
+
+    if args_options:
+        cmd += f" {args_options}"
+
+    if cfg_options:
+        cmd += f" --cfg-options {cfg_options}"
+
+    logging.info(f"training command: {cmd}")
+    subprocess.run(cmd.split(), check=True)
+
+    # save the last checkpoint
+    write_mmyolo_training_result(cfg)
+    return 0
+
+
+if __name__ == '__main__':
+    cfg = get_merged_config()
+    os.environ.setdefault('PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION', 'python')
+    sys.exit(main(cfg))


### PR DESCRIPTION
# 开发文档

## 训练

### 训练脚本调用链

1. 启动镜像时调用 `bash /usr/bin/start.sh`

2. `start.sh` 调用  `python3 ymir/start.py`

3. `start.py` 调用  `python3 ymir/ymir_training.py`

4. `ymir_training.py` 调用 `bash tools/dist_train.sh ...`

### 核心功能实现

- 数据格式转换

在 `ymir_training.py` 中首次调用 `convert_ymir_to_coco()` 进行数据格式转换，将 `det-ark:raw` 对应的 `xmin, ymin, xmax, ymax, image_quality, rotate_angle` 转换为 `qbox` 存到coco标注中的 `segmentation` 字段中。 后续调用 `convert_ymir_to_coco()` 仅获得数据集信息。

```python
for ann_line in open(ann_file, "r").readlines():
    ann_strlist = ann_line.strip().split(",")
    class_id, x1, y1, x2, y2 = [int(s) for s in ann_strlist[0:5]]
    angle = float(ann_strlist[6])

    bbox_xc = (x1 + x2) / 2
    bbox_yc = (y1 + y2) / 2
    bbox_width = x2 - x1
    bbox_height = y2 - y1
    rbox = torch.from_numpy(np.array([[bbox_xc, bbox_yc, bbox_width, bbox_height, angle]]))
    qbox = rbox2qbox(rbox)
    # hbox = rbox2hbox(rbox)

    bbox_area = bbox_width * bbox_height
    bbox_quality = (float(ann_strlist[5]) if len(ann_strlist) > 5 and ann_strlist[5].isnumeric() else 1)
    ann_info = dict(
        bbox=[x1, y1, bbox_width, bbox_height],  # x,y,width,height
        area=bbox_area,
        score=1.0,
        bbox_quality=bbox_quality,
        rotate_angle=angle,
        iscrowd=0,
        segmentation=qbox.cpu().numpy().tolist(),
        category_id=class_id + cat_id_start,  # start from cat_id_start
        id=ann_id,
        image_id=img_id,
    )
    data["annotations"].append(ann_info)
    ann_id += 1
```

- 加载数据集

    - 参考 `configs/_base_/datasets/ymir_coco.py`， 基于 **mmdet.CocoDataset** 加载转换后的数据集， 通过 **train_pipeline**, **val_pipeline** 中的 `dict(type='ConvertMask2BoxType', box_type='rbox')` 将 segmentation 字段中的 **mask** 转换为训练要使用的 `rbox` 格式。

- 数据集评测

    - 采用常用数据集**dota**的评测指标 **dict(type='DOTAMetric', metric='mAP')**

- 加载预训练权重

    - 参考 `get_best_weight_file()`

    - 如果用户提供预训练权重， 则先其中找带 `best_` 或 `mAP_` 的权重，其次找带 `epoch_` 的权重， 最后选择其中最新的。

    - 如果用户没有提供预训练权重，则在镜像的 `/weights` 目录下， 通过超参数 `model_name` 获得 `config_file` 再通过相似度找到最相似的权重文件。

- 加载超参数

    - 参考 `modify_mmengine_config()`, 将ymir超参数覆盖 `mmengine.config.Config`

- 写进度

    - 参考 `YmirTrainingMonitorHook`, 该 hook 可实时返回进度信息， 并保存最新的权重文件到ymir中，以支持提前终止训练的功能。

- 写结果文件

    - 参考 `YmirTrainingMonitorHook` 与 `write_mmyolo_training_result()`, 其中后者支持依据超参数 `max_keep_checkpoints` 保存多个权重文件。

## 推理

1. 启动镜像时调用 `bash /usr/bin/start.sh`

2. `start.sh` 调用  `python3 ymir/start.py`

3. `start.py` 调用  `python3 ymir/ymir_infer.py`

    - 调用 `init_detector()` 与 `inference_detector()` 获取推理结果

    - 调用 `mmdet_result_to_ymir()` 将mmdet推理结果转换为ymir格式

    - 调用 `rw.write_infer_result()` 保存推理结果

## 挖掘

1. 启动镜像时调用 `bash /usr/bin/start.sh`

2. `start.sh` 调用  `python3 ymir/start.py`

3. `start.py` 调用  `python3 ymir/ymir_mining.py`

    - 调用 `init_detector()` 与 `inference_detector()` 获取推理结果

    - 调用 `compute_score()` 计算挖掘分数

    - 调用 `rw.write_mining_result()` 保存挖掘结果
